### PR TITLE
Fixed long title overflow

### DIFF
--- a/src/html/popup/settings.vue
+++ b/src/html/popup/settings.vue
@@ -116,8 +116,7 @@
 					>
 						<img :src="presence.metadata.logo" draggable="false" />
 						<h1>
-							{{ presence.metadata.service }}
-							<span v-if="presence.tmp">TMP</span>
+							<span v-if="presence.tmp">TMP</span>{{ presence.metadata.service }}
 						</h1>
 						<i
 							v-if="
@@ -708,6 +707,10 @@
 						font-weight: normal;
 						justify-content: center;
 
+						max-width: 100%;
+						overflow-x: hidden;
+						text-overflow: ellipsis;
+
 						span {
 							font-size: 10px;
 
@@ -717,6 +720,9 @@
 							padding: 2px 4px;
 							border-radius: 5px;
 							position: relative;
+
+							margin-right: 5px;
+							top: -2px;
 						}
 					}
 


### PR DESCRIPTION
Also moved TMP labels to front to avoid changing the structure too much (it also looks better for me, specially since all TMP labels will be aligned at start if you have more than one local presence)
![2020-04-28_11-52-30](https://user-images.githubusercontent.com/8256351/80474004-3f8b5280-8947-11ea-9f52-236bff2f5b3b.png)

Task: #4rhcjh