### PR TITLE
Popup: Make presence store button uses blurple SCSS variable

### DIFF
--- a/src/html/popup/settings.vue
+++ b/src/html/popup/settings.vue
@@ -767,7 +767,7 @@
 
 				font-weight: 600;
 				width: 90%;
-				background-color: #7289da;
+				background-color: $blurple;
 				justify-self: center;
 				padding: 5px 5px;
 				font-size: 17px;


### PR DESCRIPTION
Currently just uses hard coded hex color even though the blurple SCSS variable has the same color.