### PR TITLE
fix: set correct start timestamp

### DIFF
--- a/src/util/presence/devHelper.ts
+++ b/src/util/presence/devHelper.ts
@@ -512,7 +512,7 @@ class Presence {
 	 * @param {Number} elementDuration Element duration seconds
 	 */
 	getTimestamps(elementTime: number, elementDuration: number) {
-		const startTime = Date.now(),
+		const startTime = Date.now() - elementTime,
 			endTime = Math.floor(startTime / 1000) - elementTime + elementDuration;
 		return [Math.floor(startTime / 1000), endTime];
 	}


### PR DESCRIPTION
returns the correct start timestamp in `getTimestamps` method.

the previous way sets the current time as the start timestamp which makes discord believe that media just started playing. discord already checks the current time and compares it with the timestamps available.

here's the difference to further clarify:

- before:

![16_03_2023-19_48_Discord_7VPggqH](https://user-images.githubusercontent.com/36301891/225714568-426b8911-4452-4c87-923b-f4e4908e06cf.png)

- after:

![16_03_2023-19_46_Discord_NaPKWC7](https://user-images.githubusercontent.com/36301891/225714618-8d17fcef-74cf-42af-aca9-cca820d50e03.png)

note that discord currently does not render the shown timestamp bar by default so this is not much of an issue as of now, but this might change in the future. 